### PR TITLE
get_synonym controle

### DIFF
--- a/humumls/table.py
+++ b/humumls/table.py
@@ -153,9 +153,11 @@ class Concept(Table):
         :param cid: the cid.
         :return: A list of concept that are synonyms to the given cid.
         """
-
-        return self[cid]["rel"]["synonym"]
-
+        try:
+            return self[cid]["rel"]["synonym"]
+        except KeyError:
+            return None
+        
     def get_words(self, cid):
         """
         Gets all words which are associated with a concept ID.

--- a/humumls/table.py
+++ b/humumls/table.py
@@ -156,7 +156,7 @@ class Concept(Table):
         try:
             return self[cid]["rel"]["synonym"]
         except KeyError:
-            return None
+            return []
         
     def get_words(self, cid):
         """


### PR DESCRIPTION
most of concepts doesn't have the field synonym , for example concept C4081153
****the count of concepts that have the field synonym****
```
db.getCollection('concept').aggregate(
    { $unwind : "$rel.synonym" },
    { $group: {
        _id: '',
        count: { $sum: 1 }
    }
})
```
the result is : ***386340.0***

****and the count of all concepts**** 
db.getCollection('concept').count()
the result is : ***2396647***